### PR TITLE
Show README.md on codespace startup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,10 +4,9 @@
     "dockerfile": "../Dockerfile"
   },
   "customizations": {
-    "codespaces": {
-      // Avoid opening /README.md
-      "openFiles": []
-    },
+    // "codespaces": {
+    //  "openFiles": []  // Uncomment this block to avoid opening /README.md
+    // },
     "vscode": {
       "settings": {
           "terminal.integrated.defaultProfile.linux": "bash",


### PR DESCRIPTION
Actually because the terminal panel will not open spanning the full screen/window height, why not show the `README.md` in a separate panel, which is the default.