### PR TITLE
Add metadata.yml & fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Annif tutorial
 
-The tutorial includes short **video presentatios** and **hands-on exercises**. 
+The tutorial includes short **video presentations** and **hands-on exercises**. 
 Two example [data sets](data-sets) are provided to be used in the exercises.
 
 The tutorial was initially organized at

--- a/metadata.yml
+++ b/metadata.yml
@@ -32,7 +32,7 @@ creator:
       type: Organization
   - givenName: Mona
     familyName: Lehtinen
-    id: https://orcid.org/0009-0004-1260-823X
+    id: https://orcid.org/0000-0002-4735-0214
     type: Person
     affiliation:
       name: National Library of Finland

--- a/metadata.yml
+++ b/metadata.yml
@@ -1,0 +1,73 @@
+'@context': https://schema.org/
+creativeWorkStatus: Published
+type: LearningResource
+name: Annif Tutorial
+description: >-
+  Many libraries and related organizations are exploring automated methods for
+  metadata creation. This Annif Tutorial offers an introduction to the
+  multilingual automated indexing tool, Annif (annif.org), which can be
+  integrated into a library’s metadata production system. The tutorial provides
+  instructional videos and exercises for self-study purposes. Learners will gain
+  hands-on experience with Annif by setting it up, training its algorithms with
+  sample data, and generating subject suggestions for new documents. The
+  tutorial includes both basic and complex scenarios.
+license: https://creativecommons.org/licenses/by/4.0/deed.de
+id: https://github.com/NatLibFi/Annif-tutorial
+creator:
+  - givenName: Juho
+    familyName: Inkinen
+    id: https://orcid.org/0000-0002-6497-6171
+    type: Person
+    affiliation:
+      name: National Library of Finland
+      type: Organization
+  - givenName: Osma
+    familyName: Suominen
+    id: https://orcid.org/0000-0003-0042-0745
+    type: Person
+    affiliation:
+      name: National Library of Finland
+      type: Organization
+  - givenName: Mona
+    familyName: Lehtinen
+    id: https://orcid.org/0009-0004-1260-823X
+    type: Person
+    affiliation:
+      name: University of Turku
+      id: https://ror.org/05vghhr25
+      type: Organization
+  - givenName: Moritz
+    familyName: Fürneisen
+    id: https://orcid.org/0009-0003-9257-0616
+    type: Person
+    affiliation:
+      name: Hans-Bredow-Institute
+      type: Organization
+  - givenName: Anna
+    familyName: Kasprzik
+    id: https://orcid.org/0000-0002-1019-3606
+    type: Person
+    affiliation:
+      name: ZBW Leibniz Information Centre for Economics
+      type: Organization
+keywords:
+  - machine-learning
+  - tutorial
+  - text-classification
+  - glam
+  - code4lib
+  - multilabel-classification
+  - subject-indexing
+  - annif
+inLanguage:
+  - en
+about:
+  - https://w3id.org/kim/hochschulfaechersystematik/n06
+  - https://w3id.org/kim/hochschulfaechersystematik/n079
+image: >-
+  https://github.com/NatLibFi/Annif-tutorial/blob/main/img/intro-slides-1.png?raw=true
+learningResourceType:
+  - https://w3id.org/kim/hcrt/course
+educationalLevel:
+  - https://w3id.org/kim/educationalLevel/level_C
+datePublished: '2019-10-02'

--- a/metadata.yml
+++ b/metadata.yml
@@ -20,6 +20,7 @@ creator:
     type: Person
     affiliation:
       name: National Library of Finland
+      id: https://ror.org/03qr6jw57
       type: Organization
   - givenName: Osma
     familyName: Suominen
@@ -27,14 +28,15 @@ creator:
     type: Person
     affiliation:
       name: National Library of Finland
+      id: https://ror.org/03qr6jw57
       type: Organization
   - givenName: Mona
     familyName: Lehtinen
     id: https://orcid.org/0009-0004-1260-823X
     type: Person
     affiliation:
-      name: University of Turku
-      id: https://ror.org/05vghhr25
+      name: National Library of Finland
+      id: https://ror.org/03qr6jw57
       type: Organization
   - givenName: Moritz
     familyName: Fürneisen


### PR DESCRIPTION
Hi everybody, hbz and TIB are jointly developing and operating the [OER Search Index (OERSI)](https://oersi.org). I thought the Annif tutorial would be a good resource to be findable in OERSI. There is a [workflow to include a GitHub repo in OERSI](https://oersi.org/resources/pages/de/docs/sources/gitlab_github/). If you merge this PR and additionally add the topic "open-educational-resources" to the repo, OERSI should automatically start indexing the tutorial.